### PR TITLE
Match Team Colors to Table Colors

### DIFF
--- a/scripts/play-game.css
+++ b/scripts/play-game.css
@@ -1,3 +1,7 @@
+body {
+  background: #a0a0a0;
+}
+
 .player-image {
     width:75%;
     margin-left: auto;
@@ -8,13 +12,28 @@
     width:100%
 }
 
-.btn-primary {
+.btn-black, .btn-black:hover, .btn-black:focus {
     background: #000000;
     border-color: #000000;
+    color: #FFFFFF;
 }
 
-.btn-danger {
+.btn-yellow, .btn-yellow:hover, .btn-yellow:focus {
     background: #ffe900;
     border-color: #ffe900;
     color: #000000;
+}
+
+.text-yellow {
+  color: #ffe900;
+  font-weight:bold;
+}
+
+.text-black {
+  color: #000000;
+  font-weight:bold;
+}
+
+.text-center {
+  font-weight:bold;
 }

--- a/scripts/play-game.css
+++ b/scripts/play-game.css
@@ -7,3 +7,14 @@
 .player-image img {
     width:100%
 }
+
+.btn-primary {
+    background: #000000;
+    border-color: #000000;
+}
+
+.btn-danger {
+    background: #ffe900;
+    border-color: #ffe900;
+    color: #000000;
+}

--- a/scripts/play-game.css
+++ b/scripts/play-game.css
@@ -12,13 +12,13 @@ body {
     width:100%
 }
 
-.btn-black, .btn-black:hover, .btn-black:focus {
+.btn-black, .btn-black:hover {
     background: #000000;
     border-color: #000000;
     color: #FFFFFF;
 }
 
-.btn-yellow, .btn-yellow:hover, .btn-yellow:focus {
+.btn-yellow, .btn-yellow:hover {
     background: #ffe900;
     border-color: #ffe900;
     color: #000000;

--- a/views/play_game.html
+++ b/views/play_game.html
@@ -82,7 +82,7 @@
         defensive_shots,
         game.blue_elo_points_to_gain(),
         game.red_elo_points_to_gain(),
-        "btn-primary btn-blue btn-blue-d")}}
+        "btn-black btn-blue btn-blue-d")}}
 
     {{score_button(
         game,
@@ -92,7 +92,7 @@
         offensive_shots,
         game.red_elo_points_to_gain(),
         game.blue_elo_points_to_gain(),
-        "btn-danger btn-red btn-red-o")}}
+        "btn-yellow btn-red btn-red-o")}}
 
 </div>
 
@@ -101,12 +101,12 @@
 {# Scores: #}
 <div class="row">
     <div class="col-xs-6">
-        <h1 class="text-right text-primary blue-score" data-game-length="{{game.length}}">
+        <h1 class="text-right text-black blue-score" data-game-length="{{game.length}}">
             {{game.blue_shots | length}}
         </h1>
     </div>
     <div class="col-xs-6">
-        <h1 class="text-left text-danger red-score" data-game-length="{{game.length}}">
+        <h1 class="text-left text-yellow red-score" data-game-length="{{game.length}}">
             {{game.red_shots | length}}
         </h1>
     </div>
@@ -124,7 +124,7 @@
         offensive_shots,
         game.blue_elo_points_to_gain(),
         game.red_elo_points_to_gain(),
-        "btn-primary btn-blue btn-blue-o")}}
+        "btn-black btn-blue btn-blue-o")}}
 
     {{score_button(
         game,
@@ -134,7 +134,7 @@
         defensive_shots,
         game.red_elo_points_to_gain(),
         game.blue_elo_points_to_gain(),
-        "btn-danger btn-red btn-red-d")}}
+        "btn-yellow btn-red btn-red-d")}}
 
 </div>
 


### PR DESCRIPTION
### Motivation
The Tornado table has black and yellow sides, so it would make sense to match those colors in the app so that players can quickly determine which side of the table on which to position themselves.

### What I Did
- Determined that a deep edit of all of the references to red and blue colors throughout the app would be a much larger task.
- Decided on a small CSS tweak as a first iteration.
- Implemented the tweak in the `play-game.css` file.