### PR TITLE
Add Scores to List of Games

### DIFF
--- a/scripts/play-game.css
+++ b/scripts/play-game.css
@@ -7,3 +7,14 @@
 .player-image img {
     width:100%
 }
+
+.btn-primary {
+    background: #000000;
+    border-color: #000000;
+}
+
+.btn-danger {
+    background: #ffe900;
+    border-color: #ffe900;
+    color: #000000;
+}

--- a/views/games.html
+++ b/views/games.html
@@ -25,16 +25,22 @@
                 Time Stamp
             </th>
             <th>
-                Red Offense
+                Yellow Offense
             </th>
             <th>
-                Red Defense
+                Yellow Defense
             </th>
             <th>
-                Blue Offense
+                Black Offense
             </th>
             <th>
-                Blue Defense
+                Black Defense
+            </th>
+            <th>
+                Black Score
+            </th>
+            <th>
+                Yellow Score
             </th>
             <th>
             </th>
@@ -58,6 +64,12 @@
             </td>
             <td class="col-xs-2">
                 {{players[game.blue_d]}}
+            </td>
+            <td class="col-xs-2" data-game-length="{{game.length}}">
+                {{game.blue_shots | length}}
+            </td>
+            <td class="col-xs-2" data-game-length="{{game.length}}">
+                {{game.red_shots | length}}
             </td>
             <td class="col-xs-2">
                 <a href="/games/play?key={{game.key.urlsafe()}}">Resume</a>


### PR DESCRIPTION
_Note: Depends on and includes changes from #10._

### Motivation
It would be helpful to be able to see scores of past games without having to click the "Resume" button to open up the game from the games list. This screen also needs updated with new color dialogue to match the new yellow and black color updates.

### What I Did
- Updated the dialogue to match new colors.
- Added new headers and cells to the table to display scores for each game.

_Note: Might want to test these changes on iPad before implementing._