### PR TITLE
Fix to improve behavior when wrong # of players chosen

### DIFF
--- a/controllers/game.py
+++ b/controllers/game.py
@@ -91,7 +91,7 @@ class NewGame(webapp2.RequestHandler):
 
         # Incorrect number of players:
         if len(url_keys) != 4:
-            players = Player.query(Player.deleted == False).order(Player.name)
+            players = Player.query(Player.deleted == False).order(-Player.last_played, -Player.total_games)
             model = {
                 'players':players,
                 'error':'Please select exactly 4 players'


### PR DESCRIPTION
Making sure that the error screen after accidentally starting a new game with too few players renders the player selection list in the same sort order as the typical "new game" screen.

@nathanjcochran you seemed really peeved when the app did this to you today.. so I wanted to fix it up for you. 